### PR TITLE
chore: use SPDX identifier Apache-2.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The volttron-listener agent allows publishing of message bus traf
 authors = [
     "VOLTTRON Team <volttron@pnnl.gov>",
 ]
-license = "Apache License 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/eclipse-volttron/volttron-listener"
 homepage = "https://github.com/eclipse-volttron/volttron-listener"


### PR DESCRIPTION
Normalize the license field in `pyproject.toml` to the SPDX identifier `Apache-2.0`.